### PR TITLE
Fix: subscription creation

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -2,9 +2,13 @@ class Api::V1::SubscriptionsController < ApplicationController
   def create
     @customer = Customer.find(params[:customer_id])
     @tea = Tea.find(params[:tea_id])
-    @subscription = @customer.subscriptions.new(subscription_params)
-    @subscription.update(title: "#{@customer.first_name}'s #{@tea.name} Subscription",
-                         status: 'Active')
+    @subscription = Subscription.new(tea_id: @tea.id, customer_id: @customer.id)
+    @subscription.update(
+      title: "#{@customer.first_name}'s #{@tea.name} Subscription",
+      price: subscription_params[:price],
+      frequency: subscription_params[:frequency],
+      status: 'Active'
+    )
     @subscription.save
     render json: SubscriptionSerializer.new(@subscription), status: :created
   end
@@ -23,6 +27,6 @@ class Api::V1::SubscriptionsController < ApplicationController
   private
 
   def subscription_params
-    params.require(:subscription).permit(:price, :frequency, :tea_id, :status)
+    params.require(:subscription).permit(:price, :frequency, :status)
   end
 end

--- a/spec/requests/api/v1/subscriptions_request_spec.rb
+++ b/spec/requests/api/v1/subscriptions_request_spec.rb
@@ -6,12 +6,8 @@ describe 'Tea Time API' do
 
   it 'creates a subscription to a tea for a customer' do
     subscription_params = {
-      title: "#{customer.first_name}'s #{tea.name} Subscription",
       price: '4.99',
-      status: 'Active',
-      frequency: 'Monthly',
-      tea_id: tea.id,
-      customer_id: customer.id
+      frequency: 'Monthly'
     }
     headers = { 'CONTENT_TYPE' => 'application/json' }
     post "/api/v1/customers/#{customer.id}/subscriptions/#{tea.id}",
@@ -29,12 +25,8 @@ describe 'Tea Time API' do
 
   it 'updates status of subscription' do
     subscription_params = {
-      title: "#{customer.first_name}'s #{tea.name} Subscription",
       price: '4.99',
-      status: 'Active',
-      frequency: 'Monthly',
-      tea_id: tea.id,
-      customer_id: customer.id
+      frequency: 'Monthly'
     }
     headers = { 'CONTENT_TYPE' => 'application/json' }
 
@@ -57,6 +49,7 @@ describe 'Tea Time API' do
     expect(response).to be_successful
 
     current_status = Subscription.last.status
+
     expect(current_status).to_not eq previous_status
 
     subscription_json = JSON.parse(response.body, symbolize_names: true)[:data]
@@ -71,10 +64,9 @@ describe 'Tea Time API' do
   it 'gets all subscriptions for a customer' do
     tea_list = create_list(:tea, 5)
     subscription_list = tea_list.map do |tea|
-      create(:subscription,
-             { customer_id: customer.id,
-               tea_id: tea.id,
-               title: "#{customer.first_name}'s #{tea.name} Subscription" })
+      create(:subscription, { customer_id: customer.id,
+                              tea_id: tea.id,
+                              title: "#{customer.first_name}'s #{tea.name} Subscription" })
     end
 
     get "/api/v1/customers/#{customer.id}/subscriptions"


### PR DESCRIPTION
Previously, app was expecting user to pass in customer id and tea id using in the body of their request to create a subscription. This was silly and redundant. Fixed subscription_controller to be able to use the ids coming through the URI. All else functions as normal and tests pass.